### PR TITLE
Aplicar el principio OCP para la impresión de vehículos

### DIFF
--- a/tp1/src/Camion.java
+++ b/tp1/src/Camion.java
@@ -11,7 +11,8 @@ public class Camion extends Vehiculo {
         return tieneAcoplado;
     }
 
-    public void setTieneAcoplado(boolean tieneAcoplado) {
-        this.tieneAcoplado = tieneAcoplado;
+    @Override
+    public void imprimir(VehiculoPrinter printer) {
+        printer.imprimirInfoCamion(this);
     }
 }

--- a/tp1/src/Imprimible.java
+++ b/tp1/src/Imprimible.java
@@ -1,0 +1,10 @@
+// Imprimible.java
+public abstract class Imprimible {
+    /**
+     * Método abstracto que define la acción de "imprimir"
+     * para cualquier clase que herede de Imprimible.
+     *
+     * @param printer La instancia de VehiculoPrinter que realizará la impresión.
+     */
+    public abstract void imprimir(VehiculoPrinter printer);
+}

--- a/tp1/src/Vehiculo.java
+++ b/tp1/src/Vehiculo.java
@@ -1,11 +1,10 @@
 // Vehiculo.java
-public class Vehiculo {
+public class Vehiculo extends Imprimible {
     private String patente;
     private String marca;
     private int año;
     private double capacidadCargaKg;
 
-    // Constructor
     public Vehiculo(String patente, String marca, int año, double capacidadCargaKg) {
         this.patente = patente;
         this.marca = marca;
@@ -13,15 +12,24 @@ public class Vehiculo {
         this.capacidadCargaKg = capacidadCargaKg;
     }
 
-    // Getters
-    public String getPatente() { return patente; }
-    public String getMarca() { return marca; }
-    public int getAño() { return año; }
-    public double getCapacidadCargaKg() { return capacidadCargaKg; }
+    public String getPatente() {
+        return patente;
+    }
 
-    // Setters (opcional, los incluyo por completitud)
-    public void setPatente(String patente) { this.patente = patente; }
-    public void setMarca(String marca) { this.marca = marca; }
-    public void setAño(int año) { this.año = año; }
-    public void setCapacidadCargaKg(double capacidadCargaKg) { this.capacidadCargaKg = capacidadCargaKg; }
+    public String getMarca() {
+        return marca;
+    }
+
+    public int getAño() {
+        return año;
+    }
+
+    public double getCapacidadCargaKg() {
+        return capacidadCargaKg;
+    }
+
+    @Override
+    public void imprimir(VehiculoPrinter printer) {
+        printer.imprimirInfoVehiculo(this);
+    }
 }

--- a/tp1/src/VehiculoPrinter.java
+++ b/tp1/src/VehiculoPrinter.java
@@ -1,14 +1,18 @@
 // VehiculoPrinter.java
 public class VehiculoPrinter {
-    public void imprimir(Vehiculo vehiculo) {
+    public void imprimir(Imprimible imprimible) {
+        imprimible.imprimir(this);
+    }
+
+    public void imprimirInfoVehiculo(Vehiculo vehiculo) {
         System.out.println("Patente: " + vehiculo.getPatente());
         System.out.println("Marca: " + vehiculo.getMarca());
         System.out.println("Año: " + vehiculo.getAño());
         System.out.println("Capacidad de carga: " + vehiculo.getCapacidadCargaKg() + " kg");
+    }
 
-        if (vehiculo instanceof Camion) {
-            Camion camion = (Camion) vehiculo;
-            System.out.println("¿Tiene acoplado? " + (camion.tieneAcoplado() ? "Sí" : "No"));
-        }
+    public void imprimirInfoCamion(Camion camion) {
+        imprimirInfoVehiculo(camion); // Imprime la información básica del vehículo
+        System.out.println("¿Tiene acoplado? " + (camion.tieneAcoplado() ? "Sí" : "No"));
     }
 }


### PR DESCRIPTION
Implementa el principio Abierto/Cerrado (OCP) utilizando una interfaz Imprimible. Ahora, nuevos tipos de vehículos pueden definir su propia lógica de impresión sin necesidad de modificar la clase VehiculoPrinter. Closes #7 